### PR TITLE
Fix(SensorsList): Don't allow submission of sensor form when errors

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -17,7 +17,7 @@ import "../src/style/global.css";
 const publicURL = process.env.NEXT_PUBLIC_WEB_URL || "";
 
 if (process.env.NODE_ENV !== "production") {
-  // require("../src/mocks/index");
+  require("../src/mocks/index");
 }
 
 const App: FC<{

--- a/src/components/SensorsList/SensorsList.test.tsx
+++ b/src/components/SensorsList/SensorsList.test.tsx
@@ -327,4 +327,70 @@ describe("component SensorsList", () => {
       expect(screen.getByText(/Hello/gi)).toBeInTheDocument()
     );
   });
+  it("should not submit when the device Id field has an error", () => {
+    const CustomWrapper: FC = () => {
+      const sensor = {
+        id: 124142,
+        externalId: "",
+        name: "My sensor 1",
+        lastRecordedAt: null,
+      };
+
+      return <SensorsList {...defaults} sensors={[sensor]} />;
+    };
+    render(<CustomWrapper />);
+
+    const editButton1 = screen.getByText(/Bearbeiten/gi);
+    expect(editButton1).toBeInTheDocument();
+
+    fireEvent.click(editButton1);
+
+    const saveButton1 = screen.getByText(/Speichern/gi);
+    expect(saveButton1).toBeInTheDocument();
+
+    const errorMsg1 = screen.getByText(/Min. 3 Zeichen/gi);
+    expect(errorMsg1).toBeInTheDocument();
+
+    fireEvent.click(saveButton1);
+
+    // Nothing should have happend, things should be the same
+    const saveButton2 = screen.getByText(/Speichern/gi);
+    expect(saveButton2).toBeInTheDocument();
+
+    const errorMsg2 = screen.getByText(/Min. 3 Zeichen/gi);
+    expect(errorMsg2).toBeInTheDocument();
+  });
+  it("should not submit when the device Id field has an error", () => {
+    const CustomWrapper: FC = () => {
+      const sensor = {
+        id: 124142,
+        externalId: "my-sensor-1",
+        name: "",
+        lastRecordedAt: null,
+      };
+
+      return <SensorsList {...defaults} sensors={[sensor]} />;
+    };
+    render(<CustomWrapper />);
+
+    const editButton1 = screen.getByText(/Bearbeiten/gi);
+    expect(editButton1).toBeInTheDocument();
+
+    fireEvent.click(editButton1);
+
+    const saveButton1 = screen.getByText(/Speichern/gi);
+    expect(saveButton1).toBeInTheDocument();
+
+    const errorMsg1 = screen.getByText(/Min. 3 Zeichen/gi);
+    expect(errorMsg1).toBeInTheDocument();
+
+    fireEvent.click(saveButton1);
+
+    // Nothing should have happend, things should be the same
+    const saveButton2 = screen.getByText(/Speichern/gi);
+    expect(saveButton2).toBeInTheDocument();
+
+    const errorMsg2 = screen.getByText(/Min. 3 Zeichen/gi);
+    expect(errorMsg2).toBeInTheDocument();
+  });
 });

--- a/src/components/SensorsList/SensorsListEditRow.tsx
+++ b/src/components/SensorsList/SensorsListEditRow.tsx
@@ -190,9 +190,11 @@ export const SensorsListEditRow: FC<SensorsListEditRowPropType> = ({
       <Button2EditField>
         <span className='h-10 flex items-center'>
           <ButtonTextLink
+            disabled={Boolean(deviceIdError || deviceNameError)}
             onClick={evt => {
               evt.preventDefault();
               evt.stopPropagation();
+              if (deviceIdError || deviceNameError) return;
               onSubmit();
             }}
           >


### PR DESCRIPTION
It was possible to submit a sensor form even when the js validation was invalid. This fixes it by ignoring clicks on submit when errors are still there.