### PR TITLE
fix(ActiveLink): Fix styles of active links to avoid layout shift

### DIFF
--- a/src/components/ActiveLink/index.tsx
+++ b/src/components/ActiveLink/index.tsx
@@ -19,17 +19,15 @@ export const ActiveLink: FC<ActiveLinkPropType> = ({
   const { asPath } = router || {};
   const child = Children.only(children) as ReactElement<HTMLAnchorElement>;
   const childClassName = child.props.className || "";
+  const isActive = asPath && (asPath === href || asPath === props.as);
 
-  const className =
-    asPath && (asPath === href || asPath === props.as)
-      ? `${childClassName} ${activeClassName}`.trim()
-      : childClassName;
+  const className = isActive
+    ? [activeClassName, childClassName].join(" ").trim()
+    : childClassName;
 
   return (
     <Link href={href} {...props}>
-      {React.cloneElement(child, {
-        className: className || "",
-      })}
+      {React.cloneElement(child, { className })}
     </Link>
   );
 };

--- a/src/components/DocsSidebar/__snapshots__/DocsSidebar.stories.storyshot
+++ b/src/components/DocsSidebar/__snapshots__/DocsSidebar.stories.storyshot
@@ -23,7 +23,7 @@ exports[`Storyshots Navigation/DocsSidebar Default 1`] = `
         >
           <li>
             <a
-              className="focus-offset underline transition hover:opacity-60 cursor-pointer text-left text-blue-500 focus:ring-blue-500"
+              className="navigation-link p-4 block sm:inline"
               href="/docs/about"
               onClick={[Function]}
               onMouseEnter={[Function]}
@@ -33,7 +33,7 @@ exports[`Storyshots Navigation/DocsSidebar Default 1`] = `
           </li>
           <li>
             <a
-              className="focus-offset underline transition hover:opacity-60 cursor-pointer text-left text-blue-500 focus:ring-blue-500"
+              className="navigation-link p-4 block sm:inline"
               href="/docs/participate"
               onClick={[Function]}
               onMouseEnter={[Function]}
@@ -52,7 +52,7 @@ exports[`Storyshots Navigation/DocsSidebar Default 1`] = `
         >
           <li>
             <a
-              className="focus-offset underline transition hover:opacity-60 cursor-pointer text-left text-blue-500 focus:ring-blue-500"
+              className="navigation-link p-4 block sm:inline"
               href="/docs"
               onClick={[Function]}
               onMouseEnter={[Function]}
@@ -62,7 +62,7 @@ exports[`Storyshots Navigation/DocsSidebar Default 1`] = `
           </li>
           <li>
             <a
-              className="focus-offset underline transition hover:opacity-60 cursor-pointer text-left text-blue-500 focus:ring-blue-500"
+              className="navigation-link p-4 block sm:inline"
               href="/docs/tutorial"
               onClick={[Function]}
               onMouseEnter={[Function]}

--- a/src/components/DocsSidebar/index.tsx
+++ b/src/components/DocsSidebar/index.tsx
@@ -1,5 +1,4 @@
 import { ActiveLink } from "@components/ActiveLink";
-import { TextLink } from "@components/TextLink";
 import { FC } from "react";
 
 interface PageType {
@@ -40,11 +39,10 @@ const PagesGroup: FC<PagesGroupPropType> = ({ title, pages }) => (
     <ul className='list-none mb-8 2xl:text-lg'>
       {pages.map(page => (
         <li key={page.path}>
-          <ActiveLink
-            activeClassName='no-underline font-bold hover:opacity-100'
-            href={page.path}
-          >
-            <TextLink href={page.path}>{page.title}</TextLink>
+          <ActiveLink activeClassName='navigation-link-active' href={page.path}>
+            <a href={page.path} className='navigation-link p-4 block sm:inline'>
+              {page.title}
+            </a>
           </ActiveLink>
         </li>
       ))}

--- a/src/components/Header/__snapshots__/Header.stories.storyshot
+++ b/src/components/Header/__snapshots__/Header.stories.storyshot
@@ -46,13 +46,13 @@ exports[`Storyshots Layout/Header Logged In 1`] = `
       className="fixed sm:static top-16 sm:top-auto left-0 sm:left-auto z-10 sm:z-auto w-full sm:w-auto shadow-xl sm:shadow-none py-4 px-1 sm:p-0 bg-gray-50 sm:bg-white border-t border-gray-200 sm:border-none transition opacity-0 pointer-events-none sm:opacity-100 sm:pointer-events-auto"
     >
       <ul
-        className="h-full sm:w-auto sm:flex sm:gap-8 text-gray-500 sm:mr-4"
+        className="h-full sm:w-auto sm:flex sm:gap-8 sm:mr-4"
       >
         <li
           className="sm:hidden sm:inline-block text-xl sm:text-base"
         >
           <a
-            className="hover:text-blue-500 transition p-4 sm:p-0 block sm:inline"
+            className="navigation-link p-4 block sm:inline"
             href="/"
             onClick={[Function]}
             onMouseEnter={[Function]}
@@ -64,7 +64,7 @@ exports[`Storyshots Layout/Header Logged In 1`] = `
           className=" sm:inline-block text-xl sm:text-base"
         >
           <a
-            className="hover:text-blue-500 transition p-4 sm:p-0 block sm:inline"
+            className="navigation-link p-4 block sm:inline"
             href="/projects"
             onClick={[Function]}
             onMouseEnter={[Function]}
@@ -76,7 +76,7 @@ exports[`Storyshots Layout/Header Logged In 1`] = `
           className=" sm:inline-block text-xl sm:text-base"
         >
           <a
-            className="hover:text-blue-500 transition p-4 sm:p-0 block sm:inline"
+            className="navigation-link p-4 block sm:inline"
             href="/docs"
             onClick={[Function]}
             onMouseEnter={[Function]}
@@ -291,13 +291,13 @@ exports[`Storyshots Layout/Header Logged Out 1`] = `
       className="fixed sm:static top-16 sm:top-auto left-0 sm:left-auto z-10 sm:z-auto w-full sm:w-auto shadow-xl sm:shadow-none py-4 px-1 sm:p-0 bg-gray-50 sm:bg-white border-t border-gray-200 sm:border-none transition opacity-0 pointer-events-none sm:opacity-100 sm:pointer-events-auto"
     >
       <ul
-        className="h-full sm:w-auto sm:flex sm:gap-8 text-gray-500 sm:mr-4"
+        className="h-full sm:w-auto sm:flex sm:gap-8 sm:mr-4"
       >
         <li
           className="sm:hidden sm:inline-block text-xl sm:text-base"
         >
           <a
-            className="hover:text-blue-500 transition p-4 sm:p-0 block sm:inline"
+            className="navigation-link p-4 block sm:inline"
             href="/"
             onClick={[Function]}
             onMouseEnter={[Function]}
@@ -309,7 +309,7 @@ exports[`Storyshots Layout/Header Logged Out 1`] = `
           className=" sm:inline-block text-xl sm:text-base"
         >
           <a
-            className="hover:text-blue-500 transition p-4 sm:p-0 block sm:inline"
+            className="navigation-link p-4 block sm:inline"
             href="/projects"
             onClick={[Function]}
             onMouseEnter={[Function]}
@@ -321,7 +321,7 @@ exports[`Storyshots Layout/Header Logged Out 1`] = `
           className=" sm:inline-block text-xl sm:text-base"
         >
           <a
-            className="hover:text-blue-500 transition p-4 sm:p-0 block sm:inline"
+            className="navigation-link p-4 block sm:inline"
             href="/docs"
             onClick={[Function]}
             onMouseEnter={[Function]}

--- a/src/components/HeaderMenu/__snapshots__/HeaderMenu.stories.storyshot
+++ b/src/components/HeaderMenu/__snapshots__/HeaderMenu.stories.storyshot
@@ -21,13 +21,13 @@ Array [
     className="fixed sm:static top-16 sm:top-auto left-0 sm:left-auto z-10 sm:z-auto w-full sm:w-auto shadow-xl sm:shadow-none py-4 px-1 sm:p-0 bg-gray-50 sm:bg-white border-t border-gray-200 sm:border-none transition opacity-0 pointer-events-none sm:opacity-100 sm:pointer-events-auto"
   >
     <ul
-      className="h-full sm:w-auto sm:flex sm:gap-8 text-gray-500 sm:mr-4"
+      className="h-full sm:w-auto sm:flex sm:gap-8 sm:mr-4"
     >
       <li
         className="sm:hidden sm:inline-block text-xl sm:text-base"
       >
         <a
-          className="hover:text-blue-500 transition p-4 sm:p-0 block sm:inline"
+          className="navigation-link p-4 block sm:inline"
           href="/"
           onClick={[Function]}
           onMouseEnter={[Function]}
@@ -39,7 +39,7 @@ Array [
         className=" sm:inline-block text-xl sm:text-base"
       >
         <a
-          className="hover:text-blue-500 transition p-4 sm:p-0 block sm:inline"
+          className="navigation-link p-4 block sm:inline"
           href="/projects"
           onClick={[Function]}
           onMouseEnter={[Function]}
@@ -51,7 +51,7 @@ Array [
         className=" sm:inline-block text-xl sm:text-base"
       >
         <a
-          className="hover:text-blue-500 transition p-4 sm:p-0 block sm:inline"
+          className="navigation-link p-4 block sm:inline"
           href="/docs"
           onClick={[Function]}
           onMouseEnter={[Function]}

--- a/src/components/HeaderMenu/index.tsx
+++ b/src/components/HeaderMenu/index.tsx
@@ -19,17 +19,8 @@ const pages: MenuPageType[] = [
 
 const HeaderLink: FC<MenuLinkPropType> = ({ text, href, className = "" }) => (
   <li className={`${className} sm:inline-block text-xl sm:text-base`}>
-    <ActiveLink
-      activeClassName='font-bold text-blue-500 cursor-default'
-      href={href}
-    >
-      <a
-        href={href}
-        className={[
-          "hover:text-blue-500 transition",
-          "p-4 sm:p-0 block sm:inline",
-        ].join(" ")}
-      >
+    <ActiveLink activeClassName='navigation-link-active' href={href}>
+      <a href={href} className='navigation-link p-4 block sm:inline'>
         {text}
       </a>
     </ActiveLink>
@@ -66,12 +57,7 @@ export const HeaderMenu: React.FC = () => {
             : "",
         ].join(" ")}
       >
-        <ul
-          className={[
-            "h-full sm:w-auto",
-            "sm:flex sm:gap-8 text-gray-500 sm:mr-4",
-          ].join(" ")}
-        >
+        <ul className='h-full sm:w-auto sm:flex sm:gap-8 sm:mr-4'>
           <HeaderLink href='/' text='Startseite' className='sm:hidden' />
           {pages.map(({ href, text }) => (
             <HeaderLink key={href} href={href} text={text} />

--- a/src/components/TableOfContents/__snapshots__/TableOfContents.stories.storyshot
+++ b/src/components/TableOfContents/__snapshots__/TableOfContents.stories.storyshot
@@ -15,7 +15,7 @@ Array [
         className="mb-2"
       >
         <button
-          className="text-left cursor-pointer hover:text-blue-500 transition focus:ring-2 focus:ring-offset-gray-100 focus:ring-offset-2 focus:outline-none text-gray-400"
+          className="text-left cursor-pointer hover:text-blue-500 transition focus:ring-2 focus:ring-offset-gray-100 focus:ring-offset-2 focus:outline-none leading-tight pr-1 pl-3 py-0.5 -ml-3 text-gray-400"
           onClick={[Function]}
         >
           Ingredients
@@ -25,7 +25,7 @@ Array [
         className="mb-2"
       >
         <button
-          className="text-left cursor-pointer hover:text-blue-500 transition focus:ring-2 focus:ring-offset-gray-100 focus:ring-offset-2 focus:outline-none text-gray-400"
+          className="text-left cursor-pointer hover:text-blue-500 transition focus:ring-2 focus:ring-offset-gray-100 focus:ring-offset-2 focus:outline-none leading-tight pr-1 pl-3 py-0.5 -ml-3 text-gray-400"
           onClick={[Function]}
         >
           Preparation
@@ -35,7 +35,7 @@ Array [
         className="mb-2"
       >
         <button
-          className="text-left cursor-pointer hover:text-blue-500 transition focus:ring-2 focus:ring-offset-gray-100 focus:ring-offset-2 focus:outline-none text-gray-400"
+          className="text-left cursor-pointer hover:text-blue-500 transition focus:ring-2 focus:ring-offset-gray-100 focus:ring-offset-2 focus:outline-none leading-tight pr-1 pl-3 py-0.5 -ml-3 text-gray-400"
           onClick={[Function]}
         >
           Serving

--- a/src/components/TableOfContents/index.tsx
+++ b/src/components/TableOfContents/index.tsx
@@ -84,8 +84,9 @@ export const TableOfContents: FC<TableOfContentsPropType> = ({ links }) => {
                 "hover:text-blue-500 transition",
                 "focus:ring-2 focus:ring-offset-gray-100 focus:ring-offset-2",
                 "focus:outline-none",
+                "leading-tight pr-1 pl-3 py-0.5 -ml-3",
                 activeLinkId === id
-                  ? "font-bold text-blue-500"
+                  ? "border-l-2 border-blue-500 text-blue-500"
                   : "text-gray-400",
               ].join(" ")}
             >

--- a/src/style/global.css
+++ b/src/style/global.css
@@ -5,6 +5,12 @@
   .focus-offset {
     @apply focus:ring-2 focus:ring-offset-white focus:ring-offset-2 focus:outline-none;
   }
+  .navigation-link {
+    @apply text-black opacity-75 transition hover:opacity-100 hover:text-blue-500 sm:px-1 sm:py-0.5 -ml-1 sm:inline-block;
+  }
+  .navigation-link-active {
+    @apply text-blue-500 bg-blue-50 opacity-100;
+  }
 };
 @layer base {
   @font-face {


### PR DESCRIPTION
This PR changes the style of active links, which were previously bold and could provoke layout shifts.

New look:
![image](https://user-images.githubusercontent.com/2759340/120186093-561f6f80-c213-11eb-8e8f-5e54221cd090.png)
