### PR TITLE
feat: improved token creation

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -17,7 +17,7 @@ import "../src/style/global.css";
 const publicURL = process.env.NEXT_PUBLIC_WEB_URL || "";
 
 if (process.env.NODE_ENV !== "production") {
-  require("../src/mocks/index");
+  // require("../src/mocks/index");
 }
 
 const App: FC<{

--- a/pages/account/profile.tsx
+++ b/pages/account/profile.tsx
@@ -37,7 +37,7 @@ const UserPage: FC = () => {
   return (
     <div
       className='w-full h-full relative grid place-content-center'
-      style={{ paddingTop: "5vmax" }}
+      style={{ padding: "5vmax 0" }}
     >
       <div
         className='bg-white p-8 shadow-lg gap-8 flex flex-col md:flex-row'

--- a/pages/signin.tsx
+++ b/pages/signin.tsx
@@ -32,7 +32,7 @@ const SigninPage: FC = () => {
   return (
     <div
       className='w-full h-full relative grid place-content-center'
-      style={{ paddingTop: "10vmax" }}
+      style={{ padding: "10vmax 0" }}
     >
       {isAuthenticating && <SigningInState />}
       {!isAuthenticating && magicLinkWasSent && (

--- a/pages/signup.tsx
+++ b/pages/signup.tsx
@@ -53,7 +53,7 @@ const SigninPage: FC = () => {
   return (
     <div
       className='w-full h-full relative grid place-content-center'
-      style={{ paddingTop: "10vmax" }}
+      style={{ padding: "10vmax 0" }}
     >
       {isAuthenticating && <SigningUpLoading />}
       {error && (

--- a/src/common/interfaces.ts
+++ b/src/common/interfaces.ts
@@ -230,3 +230,12 @@ export interface MarkerType {
   id: number;
   isActive: boolean;
 }
+
+export interface TokenResponseObjectType {
+  comment: string;
+  method: string;
+  url: string;
+  data: {
+    token: string;
+  };
+}

--- a/src/components/EditProjectForm/__snapshots__/EditProjectForm.stories.storyshot
+++ b/src/components/EditProjectForm/__snapshots__/EditProjectForm.stories.storyshot
@@ -123,12 +123,9 @@ exports[`Storyshots Forms/EditProjectForm With Default Values 1`] = `
         value="A location"
       />
     </div>
-    <button
-      className="mt-6 text-gray-400 underline cursor-not-allowed"
-      disabled={true}
-    >
-      Token neu generieren (derzeit nicht verfügbar)
-    </button>
+    <div
+      className="mt-12"
+    />
   </form>
   <footer
     className="mt-24"
@@ -282,12 +279,9 @@ exports[`Storyshots Forms/EditProjectForm Without Default Values 1`] = `
         type="text"
       />
     </div>
-    <button
-      className="mt-6 text-gray-400 underline cursor-not-allowed"
-      disabled={true}
-    >
-      Token neu generieren (derzeit nicht verfügbar)
-    </button>
+    <div
+      className="mt-12"
+    />
   </form>
   <footer
     className="mt-24"

--- a/src/components/EditProjectForm/index.tsx
+++ b/src/components/EditProjectForm/index.tsx
@@ -38,6 +38,7 @@ export const EditProjectForm: FC<ProjectForm> = ({
   onSubmit = console.log,
   onCancel,
   onDelete,
+  children,
 }) => {
   const {
     control,
@@ -113,12 +114,7 @@ export const EditProjectForm: FC<ProjectForm> = ({
           />
         )}
       />
-      <button
-        disabled
-        className='mt-6 text-gray-400 underline cursor-not-allowed'
-      >
-        Token neu generieren (derzeit nicht verfügbar)
-      </button>
+      <div className='mt-12'>{children}</div>
     </ProjectInfoFormWrapper>
   );
 };

--- a/src/components/ProjectCreatedInfo/__snapshots__/ProjectCreatedInfo.stories.storyshot
+++ b/src/components/ProjectCreatedInfo/__snapshots__/ProjectCreatedInfo.stories.storyshot
@@ -20,7 +20,7 @@ exports[`Storyshots Layout/ProjectCreatedInfo Default 1`] = `
     Nächste Schritte
   </h3>
   <div
-    className="mt-4"
+    className="mt-4 mb-12"
   >
     <p>
       This is a next steps description. This is a next steps description. This is a next steps description. This is a next steps description. This is a next steps description. This is a next steps description.
@@ -29,16 +29,19 @@ exports[`Storyshots Layout/ProjectCreatedInfo Default 1`] = `
       Possibly in two paragraphs. Possibly in two paragraphs. Possibly in two paragraphs. Possibly in two paragraphs. Possibly in two paragraphs. Possibly in two paragraphs.
     </p>
   </div>
-  <h4
-    className="mt-12"
-  >
-    Token
-  </h4>
-  <p
-    className="mt-2 p-3 border border-gray-200 text-gray-400 break-words"
-  >
-    Token wird generiert...
-  </p>
+  <div>
+    <p
+      id="token-display-label"
+    >
+      Token
+    </p>
+    <div
+      aria-labelledby="token-display-label"
+      className="mt-2 p-3 break-words border border-gray-200 text-gray-700"
+    >
+      Token wird generiert ...
+    </div>
+  </div>
   <footer
     className="mt-24 flex justify-end"
   >

--- a/src/components/ProjectCreatedInfo/index.tsx
+++ b/src/components/ProjectCreatedInfo/index.tsx
@@ -1,21 +1,14 @@
 import { AnchorButton } from "@components/Button";
+import { TokenDisplay } from "@components/TokenDisplay";
 import { FC, HTMLProps, useEffect, useState } from "react";
 import Link from "next/link";
 import { useProjectTokens } from "@lib/hooks/useProjectTokens";
 import { useAuth } from "@auth/Auth";
+import { TokenResponseObjectType } from "@common/interfaces";
 
 export interface ProjectCreatedInfoType extends HTMLProps<HTMLElement> {
   projectId: number;
   projectTitle: string;
-}
-
-interface TokenResponseObjectType {
-  comment: string;
-  method: string;
-  url: string;
-  data: {
-    token: string;
-  };
 }
 
 export const ProjectCreatedInfo: FC<ProjectCreatedInfoType> = ({
@@ -50,23 +43,14 @@ export const ProjectCreatedInfo: FC<ProjectCreatedInfoType> = ({
       <h3 className='mt-12 text-2xl text-blue-500 font-bold'>
         Nächste Schritte
       </h3>
-      <div className='mt-4'>{children}</div>
-      <h4 className='mt-12'>Token</h4>
-      {!token && error && (
-        <p className='mt-2 p-3 border border-gray-200 text-gray-500 break-words'>
-          Das Token konnte nicht generiert werden.
-        </p>
-      )}
-      {!token && !error && (
-        <p className='mt-2 p-3 border border-gray-200 text-gray-400 break-words'>
-          Token wird generiert...
-        </p>
-      )}
-      {token && (
-        <p className='mt-2 p-3 border border-gray-200 text-gray-500 break-words'>
-          {token}
-        </p>
-      )}
+      <div className='mt-4 mb-12'>{children}</div>
+      <TokenDisplay hasError={!!error}>
+        {!token && !error
+          ? "Token wird generiert ..."
+          : token && !error
+          ? token
+          : error}
+      </TokenDisplay>
       <footer className='mt-24 flex justify-end'>
         <Link href={`/account/projects/${projectId}`}>
           <AnchorButton href={`/account/projects/${projectId}`}>

--- a/src/components/TokenDisplay/TokenDisplay.stories.tsx
+++ b/src/components/TokenDisplay/TokenDisplay.stories.tsx
@@ -7,18 +7,24 @@ export default {
 } as Meta;
 
 const Template: Story<TokenDisplayType> = args => (
-  <TokenDisplay {...args}></TokenDisplay>
+  <TokenDisplay {...args}>{args.children}</TokenDisplay>
 );
 
+export const Default = Template.bind({});
+
 export const IsGenerating = Template.bind({});
+IsGenerating.args = {
+  children: "Token wird generiert...",
+};
 
 export const WithToken = Template.bind({});
 WithToken.args = {
-  token:
+  children:
     "123456789123456789123456789123456789123456789123456789123456789123456789123456789",
 };
 
 export const Error = Template.bind({});
 Error.args = {
-  errorMessage: "Some error message",
+  hasError: true,
+  children: "This could be a custom error message",
 };

--- a/src/components/TokenDisplay/TokenDisplay.stories.tsx
+++ b/src/components/TokenDisplay/TokenDisplay.stories.tsx
@@ -1,0 +1,24 @@
+import { Story, Meta } from "@storybook/react";
+import { TokenDisplay, TokenDisplayType } from ".";
+
+export default {
+  title: "UI Elements/TokenDisplay",
+  component: TokenDisplay,
+} as Meta;
+
+const Template: Story<TokenDisplayType> = args => (
+  <TokenDisplay {...args}></TokenDisplay>
+);
+
+export const IsGenerating = Template.bind({});
+
+export const WithToken = Template.bind({});
+WithToken.args = {
+  token:
+    "123456789123456789123456789123456789123456789123456789123456789123456789123456789",
+};
+
+export const Error = Template.bind({});
+Error.args = {
+  errorMessage: "Some error message",
+};

--- a/src/components/TokenDisplay/TokenDisplay.test.tsx
+++ b/src/components/TokenDisplay/TokenDisplay.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from "@testing-library/react";
+import { TokenDisplay } from ".";
+
+describe("TokenDisplay component", () => {
+  it("should render a loading message by default", () => {
+    render(<TokenDisplay></TokenDisplay>);
+    const loadingMessage = screen.getByText(/Token wird generiert/i);
+    expect(loadingMessage).toBeInTheDocument();
+  });
+
+  it("should render a token when provided", () => {
+    render(<TokenDisplay token='1234'></TokenDisplay>);
+    const token = screen.getByText(/1234/i);
+    expect(token).toBeInTheDocument();
+  });
+
+  it("should render an error message when error", () => {
+    render(<TokenDisplay errorMessage='Something went wrong'></TokenDisplay>);
+    const errorMessage = screen.getByText(/Something went wrong/i);
+    expect(errorMessage).toBeInTheDocument();
+  });
+
+  it("should visullay indicate error when error", () => {
+    render(<TokenDisplay errorMessage='Something went wrong'></TokenDisplay>);
+    const tokenDisplay = screen.getByLabelText("Token");
+    expect(tokenDisplay.getAttribute("class")?.includes("text-red-500")).toBe(
+      true
+    );
+    expect(tokenDisplay.getAttribute("class")?.includes("border-red-500")).toBe(
+      true
+    );
+  });
+});

--- a/src/components/TokenDisplay/TokenDisplay.test.tsx
+++ b/src/components/TokenDisplay/TokenDisplay.test.tsx
@@ -3,25 +3,27 @@ import { TokenDisplay } from ".";
 
 describe("TokenDisplay component", () => {
   it("should render a loading message by default", () => {
-    render(<TokenDisplay></TokenDisplay>);
-    const loadingMessage = screen.getByText(/Token wird generiert/i);
+    render(<TokenDisplay />);
+    const loadingMessage = screen.getByText(
+      /\* * * * * * * * * * * * * * * * * * * * * * * * * * * * * */i
+    );
     expect(loadingMessage).toBeInTheDocument();
   });
 
-  it("should render a token when provided", () => {
-    render(<TokenDisplay token='1234'></TokenDisplay>);
+  it("should render a token when provided children without error", () => {
+    render(<TokenDisplay>1234</TokenDisplay>);
     const token = screen.getByText(/1234/i);
     expect(token).toBeInTheDocument();
   });
 
   it("should render an error message when error", () => {
-    render(<TokenDisplay errorMessage='Something went wrong'></TokenDisplay>);
+    render(<TokenDisplay hasError={true}>Something went wrong</TokenDisplay>);
     const errorMessage = screen.getByText(/Something went wrong/i);
     expect(errorMessage).toBeInTheDocument();
   });
 
-  it("should visullay indicate error when error", () => {
-    render(<TokenDisplay errorMessage='Something went wrong'></TokenDisplay>);
+  it("should visually indicate error when error", () => {
+    render(<TokenDisplay hasError={true}>Something went wrong</TokenDisplay>);
     const tokenDisplay = screen.getByLabelText("Token");
     expect(tokenDisplay.getAttribute("class")?.includes("text-red-500")).toBe(
       true

--- a/src/components/TokenDisplay/__snapshots__/TokenDisplay.stories.storyshot
+++ b/src/components/TokenDisplay/__snapshots__/TokenDisplay.stories.storyshot
@@ -1,5 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Storyshots UI Elements/TokenDisplay Default 1`] = `
+<div>
+  <p
+    id="token-display-label"
+  >
+    Token
+  </p>
+  <div
+    aria-labelledby="token-display-label"
+    className="mt-2 p-3 break-words border border-gray-200 text-gray-700"
+  >
+    * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+  </div>
+</div>
+`;
+
 exports[`Storyshots UI Elements/TokenDisplay Error 1`] = `
 <div>
   <p
@@ -7,12 +23,12 @@ exports[`Storyshots UI Elements/TokenDisplay Error 1`] = `
   >
     Token
   </p>
-  <p
+  <div
     aria-labelledby="token-display-label"
     className="mt-2 p-3 break-words border border-red-500 text-red-500"
   >
-    Some error message
-  </p>
+    This could be a custom error message
+  </div>
 </div>
 `;
 
@@ -23,12 +39,12 @@ exports[`Storyshots UI Elements/TokenDisplay Is Generating 1`] = `
   >
     Token
   </p>
-  <p
+  <div
     aria-labelledby="token-display-label"
     className="mt-2 p-3 break-words border border-gray-200 text-gray-700"
   >
-    Token wird generiert ...
-  </p>
+    Token wird generiert...
+  </div>
 </div>
 `;
 
@@ -39,11 +55,11 @@ exports[`Storyshots UI Elements/TokenDisplay With Token 1`] = `
   >
     Token
   </p>
-  <p
+  <div
     aria-labelledby="token-display-label"
     className="mt-2 p-3 break-words border border-gray-200 text-gray-700"
   >
     123456789123456789123456789123456789123456789123456789123456789123456789123456789
-  </p>
+  </div>
 </div>
 `;

--- a/src/components/TokenDisplay/__snapshots__/TokenDisplay.stories.storyshot
+++ b/src/components/TokenDisplay/__snapshots__/TokenDisplay.stories.storyshot
@@ -1,0 +1,49 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Storyshots UI Elements/TokenDisplay Error 1`] = `
+<div>
+  <p
+    id="token-display-label"
+  >
+    Token
+  </p>
+  <p
+    aria-labelledby="token-display-label"
+    className="mt-2 p-3 break-words border border-red-500 text-red-500"
+  >
+    Some error message
+  </p>
+</div>
+`;
+
+exports[`Storyshots UI Elements/TokenDisplay Is Generating 1`] = `
+<div>
+  <p
+    id="token-display-label"
+  >
+    Token
+  </p>
+  <p
+    aria-labelledby="token-display-label"
+    className="mt-2 p-3 break-words border border-gray-200 text-gray-700"
+  >
+    Token wird generiert ...
+  </p>
+</div>
+`;
+
+exports[`Storyshots UI Elements/TokenDisplay With Token 1`] = `
+<div>
+  <p
+    id="token-display-label"
+  >
+    Token
+  </p>
+  <p
+    aria-labelledby="token-display-label"
+    className="mt-2 p-3 break-words border border-gray-200 text-gray-700"
+  >
+    123456789123456789123456789123456789123456789123456789123456789123456789123456789
+  </p>
+</div>
+`;

--- a/src/components/TokenDisplay/index.tsx
+++ b/src/components/TokenDisplay/index.tsx
@@ -1,0 +1,41 @@
+import { FC } from "react";
+
+export interface TokenDisplayType {
+  token?: string;
+  errorMessage?: string;
+}
+
+interface ContentsWrapperType {
+  hasError?: boolean;
+}
+
+const ContentsWrapper: React.FC<ContentsWrapperType> = ({
+  hasError,
+  children,
+}) => (
+  <p
+    aria-labelledby='token-display-label'
+    className={[
+      "mt-2 p-3 break-words",
+      `border ${hasError ? "border-red-500" : "border-gray-200"}`,
+      `${hasError ? "text-red-500" : "text-gray-700"}`,
+    ].join(" ")}
+  >
+    {children}
+  </p>
+);
+
+export const TokenDisplay: FC<TokenDisplayType> = ({ token, errorMessage }) => {
+  return (
+    <div>
+      <p id='token-display-label'>Token</p>
+      {!token && !errorMessage && (
+        <ContentsWrapper>Token wird generiert ...</ContentsWrapper>
+      )}
+      {token && !errorMessage && <ContentsWrapper>{token}</ContentsWrapper>}
+      {!token && errorMessage && (
+        <ContentsWrapper hasError>{errorMessage}</ContentsWrapper>
+      )}
+    </div>
+  );
+};

--- a/src/components/TokenDisplay/index.tsx
+++ b/src/components/TokenDisplay/index.tsx
@@ -1,40 +1,41 @@
-import { FC } from "react";
+import { FC, HTMLProps } from "react";
 
-export interface TokenDisplayType {
-  token?: string;
-  errorMessage?: string;
-}
-
-interface ContentsWrapperType {
+export interface TokenDisplayType extends HTMLProps<HTMLDivElement> {
   hasError?: boolean;
 }
 
+interface ContentsWrapperType {
+  hasErrorStyle?: boolean;
+}
+
 const ContentsWrapper: React.FC<ContentsWrapperType> = ({
-  hasError,
+  hasErrorStyle,
   children,
 }) => (
-  <p
+  <div
     aria-labelledby='token-display-label'
     className={[
       "mt-2 p-3 break-words",
-      `border ${hasError ? "border-red-500" : "border-gray-200"}`,
-      `${hasError ? "text-red-500" : "text-gray-700"}`,
+      `border ${hasErrorStyle ? "border-red-500" : "border-gray-200"}`,
+      `${hasErrorStyle ? "text-red-500" : "text-gray-700"}`,
     ].join(" ")}
   >
     {children}
-  </p>
+  </div>
 );
 
-export const TokenDisplay: FC<TokenDisplayType> = ({ token, errorMessage }) => {
+export const TokenDisplay: FC<TokenDisplayType> = ({ hasError, children }) => {
   return (
     <div>
       <p id='token-display-label'>Token</p>
-      {!token && !errorMessage && (
-        <ContentsWrapper>Token wird generiert ...</ContentsWrapper>
+      {!hasError && !children && (
+        <ContentsWrapper>
+          * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+        </ContentsWrapper>
       )}
-      {token && !errorMessage && <ContentsWrapper>{token}</ContentsWrapper>}
-      {!token && errorMessage && (
-        <ContentsWrapper hasError>{errorMessage}</ContentsWrapper>
+      {children && !hasError && <ContentsWrapper>{children}</ContentsWrapper>}
+      {hasError && children && (
+        <ContentsWrapper hasErrorStyle>{children}</ContentsWrapper>
       )}
     </div>
   );

--- a/src/components/UserProjectsNav/__snapshots__/UserProjectsNav.stories.storyshot
+++ b/src/components/UserProjectsNav/__snapshots__/UserProjectsNav.stories.storyshot
@@ -10,7 +10,7 @@ exports[`Storyshots Layout/UserProjectsNav Default 1`] = `
       className="my-4 border-opacity-100"
     >
       <button
-        className="py-0 pl-4 border-l-2 border-blue-400 focus-offset transition focus:ring-blue-500 text-blue-500 border-opacity-100"
+        className="py-0 pl-4 border-l-2 border-blue-400 focus-offset text-left transition focus:ring-blue-500 text-blue-500 border-opacity-100"
         id="user-project-item-kjasdhjkas"
         onClick={[Function]}
       >
@@ -22,7 +22,7 @@ exports[`Storyshots Layout/UserProjectsNav Default 1`] = `
       className="my-4 border-opacity-0"
     >
       <button
-        className="py-0 pl-4 border-l-2 border-blue-400 focus-offset transition focus:ring-blue-500 text-gray-500 border-opacity-0"
+        className="py-0 pl-4 border-l-2 border-blue-400 focus-offset text-left transition focus:ring-blue-500 text-gray-500 border-opacity-0"
         id="user-project-item-uisdzuada"
         onClick={[Function]}
       >
@@ -34,7 +34,7 @@ exports[`Storyshots Layout/UserProjectsNav Default 1`] = `
       className="my-4 border-opacity-0"
     >
       <button
-        className="py-0 pl-4 border-l-2 border-blue-400 focus-offset transition focus:ring-blue-500 text-gray-500 border-opacity-0"
+        className="py-0 pl-4 border-l-2 border-blue-400 focus-offset text-left transition focus:ring-blue-500 text-gray-500 border-opacity-0"
         id="user-project-item-tgedhebdm"
         onClick={[Function]}
       >
@@ -55,7 +55,7 @@ exports[`Storyshots Layout/UserProjectsNav Without Default Selected Project 1`] 
       className="my-4 border-opacity-0"
     >
       <button
-        className="py-0 pl-4 border-l-2 border-blue-400 focus-offset transition focus:ring-blue-500 text-gray-500 border-opacity-0"
+        className="py-0 pl-4 border-l-2 border-blue-400 focus-offset text-left transition focus:ring-blue-500 text-gray-500 border-opacity-0"
         id="user-project-item-kjasdhjkas"
         onClick={[Function]}
       >
@@ -67,7 +67,7 @@ exports[`Storyshots Layout/UserProjectsNav Without Default Selected Project 1`] 
       className="my-4 border-opacity-0"
     >
       <button
-        className="py-0 pl-4 border-l-2 border-blue-400 focus-offset transition focus:ring-blue-500 text-gray-500 border-opacity-0"
+        className="py-0 pl-4 border-l-2 border-blue-400 focus-offset text-left transition focus:ring-blue-500 text-gray-500 border-opacity-0"
         id="user-project-item-uisdzuada"
         onClick={[Function]}
       >
@@ -79,7 +79,7 @@ exports[`Storyshots Layout/UserProjectsNav Without Default Selected Project 1`] 
       className="my-4 border-opacity-0"
     >
       <button
-        className="py-0 pl-4 border-l-2 border-blue-400 focus-offset transition focus:ring-blue-500 text-gray-500 border-opacity-0"
+        className="py-0 pl-4 border-l-2 border-blue-400 focus-offset text-left transition focus:ring-blue-500 text-gray-500 border-opacity-0"
         id="user-project-item-tgedhebdm"
         onClick={[Function]}
       >

--- a/src/components/UserProjectsNav/index.tsx
+++ b/src/components/UserProjectsNav/index.tsx
@@ -56,7 +56,7 @@ export const UserProjectsNav: FC<UserProjectsNavType> = ({
                 id={`user-project-item-${project.projectId}`}
                 onClick={() => handleSelectProject(project.projectId)}
                 className={[
-                  `py-0 pl-4 border-l-2 border-blue-400 focus-offset transition focus:ring-blue-500`,
+                  `py-0 pl-4 border-l-2 border-blue-400 focus-offset text-left transition focus:ring-blue-500`,
                   `${
                     project.projectId === selectedProject?.projectId
                       ? "text-blue-500 border-opacity-100"

--- a/src/components/UserProjectsWrapper/__snapshots__/UserProjectsWrapper.stories.storyshot
+++ b/src/components/UserProjectsWrapper/__snapshots__/UserProjectsWrapper.stories.storyshot
@@ -39,7 +39,7 @@ exports[`Storyshots Layout/UserProjectsWrapper With Projects 1`] = `
             className="my-4 border-opacity-100"
           >
             <button
-              className="py-0 pl-4 border-l-2 border-blue-400 focus-offset transition focus:ring-blue-500 text-blue-500 border-opacity-100"
+              className="py-0 pl-4 border-l-2 border-blue-400 focus-offset text-left transition focus:ring-blue-500 text-blue-500 border-opacity-100"
               id="user-project-item-1"
               onClick={[Function]}
             >
@@ -51,7 +51,7 @@ exports[`Storyshots Layout/UserProjectsWrapper With Projects 1`] = `
             className="my-4 border-opacity-0"
           >
             <button
-              className="py-0 pl-4 border-l-2 border-blue-400 focus-offset transition focus:ring-blue-500 text-gray-500 border-opacity-0"
+              className="py-0 pl-4 border-l-2 border-blue-400 focus-offset text-left transition focus:ring-blue-500 text-gray-500 border-opacity-0"
               id="user-project-item-2"
               onClick={[Function]}
             >
@@ -63,7 +63,7 @@ exports[`Storyshots Layout/UserProjectsWrapper With Projects 1`] = `
             className="my-4 border-opacity-0"
           >
             <button
-              className="py-0 pl-4 border-l-2 border-blue-400 focus-offset transition focus:ring-blue-500 text-gray-500 border-opacity-0"
+              className="py-0 pl-4 border-l-2 border-blue-400 focus-offset text-left transition focus:ring-blue-500 text-gray-500 border-opacity-0"
               id="user-project-item-3"
               onClick={[Function]}
             >

--- a/src/components/UserProjectsWrapper/__snapshots__/UserProjectsWrapper.stories.storyshot
+++ b/src/components/UserProjectsWrapper/__snapshots__/UserProjectsWrapper.stories.storyshot
@@ -5,7 +5,7 @@ exports[`Storyshots Layout/UserProjectsWrapper With Projects 1`] = `
   className="max-w-screen-xl mx-auto p-6 block md:grid gap-4 grid-cols-12"
   style={
     Object {
-      "paddingTop": "5vmax",
+      "padding": "5vmax 0",
     }
   }
 >
@@ -89,7 +89,7 @@ exports[`Storyshots Layout/UserProjectsWrapper Without Projects 1`] = `
   className="max-w-screen-xl mx-auto p-6 block md:grid gap-4 grid-cols-12"
   style={
     Object {
-      "paddingTop": "5vmax",
+      "padding": "5vmax 0",
     }
   }
 >

--- a/src/components/UserProjectsWrapper/index.tsx
+++ b/src/components/UserProjectsWrapper/index.tsx
@@ -25,7 +25,7 @@ export const UserProjectsWrapper: FC<UserProjectWrapperType> = ({
   return (
     <div
       className='max-w-screen-xl mx-auto p-6 block md:grid gap-4 grid-cols-12'
-      style={{ paddingTop: "5vmax" }}
+      style={{ padding: "5vmax 0" }}
     >
       <section className='col-span-3'>
         <h1 className='text-3xl text-blue-500 font-bold mt-6'>

--- a/src/lib/hooks/useProjectTokens/useProjectTokens.test.tsx
+++ b/src/lib/hooks/useProjectTokens/useProjectTokens.test.tsx
@@ -103,7 +103,7 @@ describe("useProjectTokens", () => {
     );
 
     await waitFor(() => {
-      expect(onError).toHaveBeenLastCalledWith(true);
+      expect(onError).toHaveBeenCalled();
       expect(onSuccess).not.toHaveBeenCalled();
     });
   });


### PR DESCRIPTION
These changes enable the user to refresh a project token. More specifically:

- a generic `TokenDisplay` component is added
- the component is used on the `account/projects/{id}/edit` route for refreshing the token
- the component is now also used when a project is newly created
- an unrelated fix in the `UserProjectsNav` component was also made