### PR TITLE
feat(ProjectPreview): Show the sensors amount on each ProjectPreview

### DIFF
--- a/src/components/ProjectPreview/ProjectPreview.test.tsx
+++ b/src/components/ProjectPreview/ProjectPreview.test.tsx
@@ -1,28 +1,20 @@
 import { screen, render } from "@testing-library/react";
-import { ThemeProvider } from "theme-ui";
-import { StoreProvider } from "easy-peasy";
-import theme from "../../style/theme";
-import store from "../../state/store";
 import { ProjectPreview } from ".";
 import { getPublicProjects } from "@lib/hooks/usePublicProjects";
+
+const defaultProject = {
+  id: 0,
+  name: "Title",
+  location: "Berlin",
+  description: "Description",
+  records: [],
+  devicesNumber: 0,
+};
 
 describe("ProjectPreview component", () => {
   it("should render the title, subtitle and text", async (): Promise<void> => {
     const data = await getPublicProjects(500);
-    if (data)
-      render(
-        <StoreProvider store={store}>
-          <ThemeProvider theme={theme}>
-            <ProjectPreview
-              id={0}
-              name='Title'
-              location='Berlin'
-              description='Description'
-              records={[]}
-            />
-          </ThemeProvider>
-        </StoreProvider>
-      );
+    if (data) render(<ProjectPreview {...defaultProject} />);
 
     const title = screen.getByText(/Title/gi);
     const city = screen.getByText(/Berlin/gi);
@@ -30,5 +22,32 @@ describe("ProjectPreview component", () => {
     expect(title).toBeInTheDocument();
     expect(city).toBeInTheDocument();
     expect(description).toBeInTheDocument();
+  });
+  it("should render the sensors amount in singular, if 0", async (): Promise<void> => {
+    const data = await getPublicProjects(500);
+    if (data) render(<ProjectPreview {...defaultProject} />);
+
+    const singular = screen.getByText(/0 Sensor/gi);
+    const plural = screen.queryByText(/Sensoren/gi);
+    expect(singular).toBeInTheDocument();
+    expect(plural).not.toBeInTheDocument();
+  });
+  it("should render the sensors amount in singular, if 1", async (): Promise<void> => {
+    const data = await getPublicProjects(500);
+    if (data) render(<ProjectPreview {...defaultProject} devicesNumber={1} />);
+
+    const singular = screen.getByText(/1 Sensor/gi);
+    const plural = screen.queryByText(/Sensoren/gi);
+    expect(singular).toBeInTheDocument();
+    expect(plural).not.toBeInTheDocument();
+  });
+  it("should render the sensors amount in plural, if 2 or more", async (): Promise<void> => {
+    const data = await getPublicProjects(500);
+    if (data) render(<ProjectPreview {...defaultProject} devicesNumber={2} />);
+
+    const plural = screen.getByText(/2 Sensoren/gi);
+    const singular = screen.queryByText(/Sensor$/gi);
+    expect(plural).toBeInTheDocument();
+    expect(singular).not.toBeInTheDocument();
   });
 });

--- a/src/components/ProjectPreview/index.tsx
+++ b/src/components/ProjectPreview/index.tsx
@@ -11,6 +11,7 @@ export const ProjectPreview: FC<PublicProject> = ({
   location,
   description,
   records,
+  devicesNumber,
 }) => {
   const parentRef = useRef<HTMLDivElement>(null);
   const [svgWrapperWidth, setSvgWrapperWidth] = useState(0);
@@ -80,7 +81,13 @@ export const ProjectPreview: FC<PublicProject> = ({
               <h3 className='text-blue-500 text-xl sm:text-2xl md:text-3xl font-semibold'>
                 {name}
               </h3>
-              <h4 className='mt-4 mb-2 font-bold'>{location}</h4>
+              <p className='mt-4 mb-2 flex gap-x-2'>
+                <span className='font-bold'>{location}</span>
+                <span className='text-gray-400'>·</span>
+                <span className=''>
+                  {devicesNumber} {devicesNumber > 1 ? "Sensoren" : "Sensor"}
+                </span>
+              </p>
               <p className='text-base'>{description}</p>
             </div>
           </div>

--- a/src/lib/hooks/usePublicProjects/index.ts
+++ b/src/lib/hooks/usePublicProjects/index.ts
@@ -13,6 +13,7 @@ export interface PublicProject {
   name: string;
   description?: string;
   location?: string;
+  devicesNumber: number;
   records: DateValueType[];
 }
 
@@ -63,7 +64,6 @@ export const getPublicProjects = async (
       foreignTable: "devices.records",
       ascending: false,
     })
-    .limit(10, { foreignTable: "devices" })
     .limit(recordsLimit, { foreignTable: "devices.records" });
 
   if (error) throw error;
@@ -76,6 +76,7 @@ export const getPublicProjects = async (
         name,
         description,
         location,
+        devicesNumber: devices?.length || 0,
         records: parseDeviceRecords(devices),
       };
     }

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -81,14 +81,12 @@ const supabaseHandlers = [
     const select = query.get("select");
     // const offset = query.get("offset");
     // const limit = query.get("limit");
-    const devicesLimit = query.get("devices.limit");
     const recordsLimit = query.get("devices.records.limit");
     const recordsOrder = query.get("devices.records.order");
     const userId = query.get("userId")?.slice(3);
     if (
       recordsLimit == "500" &&
       recordsOrder == "recordedAt.desc.nullslast" &&
-      devicesLimit == "10" &&
       // limit == "10" &&
       // offset == "0" &&
       select ==


### PR DESCRIPTION
This PR adds an indication of the number of sensors on each Project Card. Getting the aggregated sum of all devices via the supabase sdk without loading all the devices isn't possible. This is only doable via the Backend. Therefore, for now, the device limit has been removed from the query. In real-case scenarios, this is probably not a problem. I already created a backend ticket to create the sum aggregation on the backend side.